### PR TITLE
Bs reaction

### DIFF
--- a/SQL/ReactionSeed.sql
+++ b/SQL/ReactionSeed.sql
@@ -1,10 +1,30 @@
 ﻿Use [Tabloid]
 Go
+DROP TABLE IF EXISTS [PostReaction];
+DROP TABLE IF EXISTS [Reaction];
+
+CREATE TABLE [Reaction] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [Name] nvarchar(50) NOT NULL,
+  [ImageLocation] nvarchar(255) NOT NULL
+)
+
+CREATE TABLE [PostReaction] (
+  [Id] integer PRIMARY KEY IDENTITY,
+  [PostId] integer NOT NULL,
+  [ReactionId] integer NOT NULL,
+  [UserProfileId] integer NOT NULL,
+
+  CONSTRAINT [FK_PostReaction_Post] FOREIGN KEY ([PostId]) REFERENCES [Post] ([Id]),
+  CONSTRAINT [FK_PostReaction_Reaction] FOREIGN KEY ([ReactionId]) REFERENCES [Reaction] ([Id]),
+  CONSTRAINT [FK_PostReaction_UserProfile] FOREIGN KEY ([UserProfileId]) REFERENCES [UserProfile] ([Id])
+)
 
 set identity_insert [Reaction] on
 
 insert into Reaction (Id, Name, ImageLocation) values (1, 'cat', 'https://image.shutterstock.com/image-photo/funny-cat-ophthalmologist-appointmet-squinting-260nw-598805597.jpg' );
 insert into Reaction (Id, Name, ImageLocation) values (2, 'dog', 'https://image.shutterstock.com/image-photo/indy-musician-guitarist-pug-dogfunny-260nw-688080844.jpg' );
+insert into Reaction (Id, Name, ImageLocation) values (3, 'thumbsUp', 'https://www.flaticon.com/svg/static/icons/svg/1170/1170168.svg' );
 
 set identity_insert [Reaction] off
 
@@ -12,4 +32,14 @@ set identity_insert [PostReaction] on
 
 insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (1, 1, 1, 3);
 insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (2, 1, 2, 3);
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (3, 1, 3, 3);
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (4, 1, 3, 5);
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (5, 1, 3, 3);
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (6, 2, 3, 2);
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (7, 2, 3, 5);
+
+
+
+
+
 set identity_insert [PostReaction] off

--- a/SQL/ReactionSeed.sql
+++ b/SQL/ReactionSeed.sql
@@ -1,0 +1,15 @@
+﻿Use [Tabloid]
+Go
+
+set identity_insert [Reaction] on
+
+insert into Reaction (Id, Name, ImageLocation) values (1, 'cat', 'https://image.shutterstock.com/image-photo/funny-cat-ophthalmologist-appointmet-squinting-260nw-598805597.jpg' );
+insert into Reaction (Id, Name, ImageLocation) values (2, 'dog', 'https://image.shutterstock.com/image-photo/indy-musician-guitarist-pug-dogfunny-260nw-688080844.jpg' );
+
+set identity_insert [Reaction] off
+
+set identity_insert [PostReaction] on
+
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (1, 1, 1, 3);
+insert into PostReaction (Id, PostId, ReactionId, UserProfileId) values (2, 1, 2, 3);
+set identity_insert [PostReaction] off

--- a/Tabloid/Controllers/CategoryController.cs
+++ b/Tabloid/Controllers/CategoryController.cs
@@ -87,28 +87,6 @@ namespace Tabloid.Controllers
         }
 
 
-        // GET: Owners/Delete/5
-        // [Authorize(Roles = "Admin")]
-        //public ActionResult Delete(int id)
-        //{
-        //    Category category = _categoryRepository.GetCategoryById(id);
-        //    if (category == null)
-        //    {
-
-        //        return NotFound();
-
-        //    }
-        //    else if (category.Id == 1)
-        //    {
-
-        //        return NotFound();
-
-        //    }
-        //    return Ok(category);
-        //}
-
-        ////PUT: Owners/Delete/5
-        //[HttpPut("{id")]
         [HttpDelete("{id}")]
         //// TRY WITH THIS LATER 
         ////[ValidateAntiForgeryToken]

--- a/Tabloid/Controllers/ReactionController.cs
+++ b/Tabloid/Controllers/ReactionController.cs
@@ -48,7 +48,14 @@ namespace Tabloid.Controllers
             return Ok(_postReactionRepository.GetAllReactionsByPostId(id));
         }
 
-        
+        //GET: ALL Reactions made on a single post
+        [HttpGet("GetAllReactionsCountedByPost/{id}")]
+        public IActionResult GetAllReactionsCountByPost(int id)
+        {
+            return Ok(_postReactionRepository.GetAllReactionsCountedByPostId(id));
+        }
+
+
 
         //POST : Add Reaction to a Post
         [HttpPost("PostReaction")]

--- a/Tabloid/Controllers/ReactionController.cs
+++ b/Tabloid/Controllers/ReactionController.cs
@@ -41,7 +41,7 @@ namespace Tabloid.Controllers
             return Ok(_postReactionRepository.GetAllPostReactions());
         }
 
-        //this will show the list of reactions for that specific post
+        //GET: ALL Reactions made on a single post
         [HttpGet("GetAllReactionsByPost/{id}")]
         public IActionResult GetAllReactionsByPost(int id)
         {
@@ -50,7 +50,7 @@ namespace Tabloid.Controllers
 
         
 
-
+        //POST : Add Reaction to a Post
         [HttpPost("PostReaction")]
         public IActionResult Post(PostReaction postReaction)
         {
@@ -61,6 +61,7 @@ namespace Tabloid.Controllers
 
         }
 
+        //POST: Create new Reaction Type
         [HttpPost]
         public IActionResult Post(Reaction reaction)
         {

--- a/Tabloid/Controllers/ReactionController.cs
+++ b/Tabloid/Controllers/ReactionController.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Tabloid.Models;
+using Tabloid.Repositories;
+
+namespace Tabloid.Controllers
+{
+//    [Authorize]
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ReactionController : ControllerBase
+    {
+        private readonly IReactionRepository _reactionRepository;
+        private readonly IPostReactionRepository _postReactionRepository;
+        private readonly IUserProfileRepository _userProfileRepository;
+        //private readonly IPostRepository _postRepository;
+
+        public ReactionController(IPostReactionRepository postReactionRepository, IReactionRepository reactionRepository, IUserProfileRepository userProfileRepository)
+        {
+            _reactionRepository = reactionRepository;
+            _postReactionRepository = postReactionRepository;
+            _userProfileRepository = userProfileRepository;
+            //_postRepository = postRepository;
+        }
+
+        [HttpGet]
+        public IActionResult GetAllReactions()
+        {
+            return Ok(_reactionRepository.GetAllReactions());
+        }
+
+        //GET: ALL PostReactions
+        [HttpGet("postReactions")]
+        public IActionResult GetAllPostReactions()
+        {
+            return Ok(_postReactionRepository.GetAllPostReactions());
+        }
+
+        //this will show the list of reactions for that specific post
+        [HttpGet("GetAllReactionsByPost/{id}")]
+        public IActionResult GetAllReactionsByPost(int id)
+        {
+            return Ok(_postReactionRepository.GetAllReactionsByPostId(id));
+        }
+
+        
+
+
+        [HttpPost("PostReaction")]
+        public IActionResult Post(PostReaction postReaction)
+        {
+
+            _postReactionRepository.AddPostReaction(postReaction);
+           
+            return CreatedAtAction(nameof(GetAllPostReactions), new { id = postReaction.Id }, postReaction);
+
+        }
+
+        [HttpPost]
+        public IActionResult Post(Reaction reaction)
+        {
+
+            _reactionRepository.AddReaction(reaction);
+           
+            return CreatedAtAction(nameof(GetAllReactions), new { id = reaction.Id }, reaction);
+
+        }
+
+        //[HttpDelete("{id}")]
+        //public IActionResult Delete(int id)
+        //{
+        //    _commentRepository.DeleteComment(id);
+        //    //return status 204
+        //    return NoContent();
+        //}
+
+
+
+
+    }
+    
+    }
+

--- a/Tabloid/Models/PostReaction.cs
+++ b/Tabloid/Models/PostReaction.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tabloid.Models
+{
+    public class PostReaction
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public int PostId { get; set; }
+        [Required]
+        public int ReactionId { get; set; }
+
+        [Required]
+        public int UserProfileId { get; set; }
+
+        public Reaction Reaction { get; set; }
+        
+
+    }
+}

--- a/Tabloid/Models/Reaction.cs
+++ b/Tabloid/Models/Reaction.cs
@@ -18,6 +18,10 @@ namespace Tabloid.Models
         [DisplayName("Image")]
         public string ImageLocation { get; set; }
 
+        public int ReactionCount { get; set; }
+
+
+
 
     }
 }

--- a/Tabloid/Models/Reaction.cs
+++ b/Tabloid/Models/Reaction.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Tabloid.Models
+{
+    public class Reaction
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        [Required]
+        [DisplayName("Image")]
+        public string ImageLocation { get; set; }
+
+
+    }
+}

--- a/Tabloid/Repositories/IPostReactionRepository.cs
+++ b/Tabloid/Repositories/IPostReactionRepository.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Tabloid.Models;
+
+namespace Tabloid.Repositories
+{
+    public interface IPostReactionRepository
+    {
+        void AddPostReaction(PostReaction postReaction);
+        List<PostReaction> GetAllReactionsByPostId(int id);
+    }
+}

--- a/Tabloid/Repositories/IPostReactionRepository.cs
+++ b/Tabloid/Repositories/IPostReactionRepository.cs
@@ -7,5 +7,6 @@ namespace Tabloid.Repositories
     {
         void AddPostReaction(PostReaction postReaction);
         List<PostReaction> GetAllReactionsByPostId(int id);
+        List<PostReaction> GetAllPostReactions();
     }
 }

--- a/Tabloid/Repositories/IPostReactionRepository.cs
+++ b/Tabloid/Repositories/IPostReactionRepository.cs
@@ -8,5 +8,7 @@ namespace Tabloid.Repositories
         void AddPostReaction(PostReaction postReaction);
         List<PostReaction> GetAllReactionsByPostId(int id);
         List<PostReaction> GetAllPostReactions();
+        List<PostReaction> GetAllReactionsCountedByPostId(int id);
+
     }
 }

--- a/Tabloid/Repositories/IReactionRepository.cs
+++ b/Tabloid/Repositories/IReactionRepository.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Tabloid.Models;
+
+namespace Tabloid.Repositories
+{
+    public interface IReactionRepository
+    {
+        void AddReaction(Reaction reaction);
+        List<Reaction> GetAllReactions();
+        Reaction GetReactionById(int id);
+    }
+}

--- a/Tabloid/Repositories/IReactionRepository.cs
+++ b/Tabloid/Repositories/IReactionRepository.cs
@@ -8,5 +8,6 @@ namespace Tabloid.Repositories
         void AddReaction(Reaction reaction);
         List<Reaction> GetAllReactions();
         Reaction GetReactionById(int id);
+
     }
 }

--- a/Tabloid/Repositories/PostReactionRepository.cs
+++ b/Tabloid/Repositories/PostReactionRepository.cs
@@ -14,7 +14,53 @@ namespace Tabloid.Repositories
     {
         public PostReactionRepository(IConfiguration config) : base(config) { }
 
+        public List<PostReaction> GetAllPostReactions()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                      SELECT pr.Id As PostReactionId, pr.PostId, pr.ReactionId, pr.UserProfileId AS UserProfileIdReactingToPost, 
+                        r.Id As ReactionId, r.Name, r.ImageLocation 
+                        FROM PostReaction pr
+                        JOIN  Reaction r
+                        ON pr.ReactionId = r.Id
+                        
+                       ";
+                    
 
+                    var postReactions = new List<PostReaction>();
+
+                    var reader = cmd.ExecuteReader();
+
+                    while (reader.Read())
+                    {
+                        PostReaction postReaction = new PostReaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("PostReactionId")),
+                            PostId = reader.GetInt32(reader.GetOrdinal("PostId")),
+                            ReactionId = reader.GetInt32(reader.GetOrdinal("ReactionId")),
+                            UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileIdReactingToPost")),
+                            Reaction = new Reaction
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("ReactionId")),
+                                Name = reader.GetString(reader.GetOrdinal("Name")),
+                                ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation"))
+                            }
+                        };
+
+                        postReactions.Add(postReaction);
+
+                    }
+
+                    reader.Close();
+
+                    return postReactions;
+                }
+            }
+        }
 
         public List<PostReaction> GetAllReactionsByPostId(int id)
         {

--- a/Tabloid/Repositories/PostReactionRepository.cs
+++ b/Tabloid/Repositories/PostReactionRepository.cs
@@ -152,33 +152,16 @@ namespace Tabloid.Repositories
 
 
                         var reactionId = reader.GetInt32(reader.GetOrdinal("ReactionId"));
-                        var anotherPostReaction = postReactions.Find(pr => pr.Id == reactionId);
+                        var anotherPostReaction = postReactions.Find(pr => pr.ReactionId == reactionId);
                         if (anotherPostReaction == null) {
 
-                            PostReaction newPostReaction = new PostReaction
-                            {
-                                Id = reader.GetInt32(reader.GetOrdinal("PostReactionId")),
-                                PostId = reader.GetInt32(reader.GetOrdinal("PostId")),
-                                ReactionId = reader.GetInt32(reader.GetOrdinal("ReactionId")),
-                                UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileIdReactingToPost")),
-                                Reaction = new Reaction
-                                {
-                                    Id = reader.GetInt32(reader.GetOrdinal("Id")),
-                                    Name = reader.GetString(reader.GetOrdinal("Name")),
-                                    ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation")),
-                                    ReactionCount = 1
-                                }
-                            };
-                            postReactions.Add(newPostReaction);
-                        }else
-                        {
+                            postReactions.Add(postReaction);
 
-                            int initalReactionIndex = postReactions.FindIndex(pr => pr.Id == reactionId);
-                            //  var newPRs= postReactions.Splice()
+                        } else {
+
+                            int initalReactionIndex = postReactions.FindIndex(pr => pr.ReactionId == reactionId);
                             postReactions[initalReactionIndex].Reaction.ReactionCount = postReactions[initalReactionIndex].Reaction.ReactionCount + 1;
-                            //anotherPostReaction.Count = (anotherPostReaction.Count + 1);
-                            //newPostReaction.IsNullOrEmpty();
-                            //postReactions.Add(anotherPostReaction);
+
                         }
                     }
                         reader.Close();

--- a/Tabloid/Repositories/PostReactionRepository.cs
+++ b/Tabloid/Repositories/PostReactionRepository.cs
@@ -110,6 +110,84 @@ namespace Tabloid.Repositories
             }
         }
 
+        public List<PostReaction> GetAllReactionsCountedByPostId(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                     SELECT pr.Id As PostReactionId, pr.PostId, pr.ReactionId, pr.UserProfileId AS UserProfileIdReactingToPost, 
+                        r.Id, r.Name, r.ImageLocation 
+                        FROM PostReaction pr
+                        JOIN  Reaction r
+                        ON pr.ReactionId = r.Id
+                        WHERE pr.PostId = @id
+                       ";
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    var postReactions = new List<PostReaction>();
+
+                    var reader = cmd.ExecuteReader();
+
+                   // var count = 1;
+
+                    while (reader.Read())
+                    {
+                        PostReaction postReaction = new PostReaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("PostReactionId")),
+                            PostId = reader.GetInt32(reader.GetOrdinal("PostId")),
+                            ReactionId = reader.GetInt32(reader.GetOrdinal("ReactionId")),
+                            UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileIdReactingToPost")),
+                            Reaction = new Reaction
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                Name = reader.GetString(reader.GetOrdinal("Name")),
+                                ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation")),
+                                ReactionCount = 1
+                            }
+                        };
+
+
+                        var reactionId = reader.GetInt32(reader.GetOrdinal("ReactionId"));
+                        var anotherPostReaction = postReactions.Find(pr => pr.Id == reactionId);
+                        if (anotherPostReaction == null) {
+
+                            PostReaction newPostReaction = new PostReaction
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("PostReactionId")),
+                                PostId = reader.GetInt32(reader.GetOrdinal("PostId")),
+                                ReactionId = reader.GetInt32(reader.GetOrdinal("ReactionId")),
+                                UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileIdReactingToPost")),
+                                Reaction = new Reaction
+                                {
+                                    Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                    Name = reader.GetString(reader.GetOrdinal("Name")),
+                                    ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation")),
+                                    ReactionCount = 1
+                                }
+                            };
+                            postReactions.Add(newPostReaction);
+                        }else
+                        {
+
+                            int initalReactionIndex = postReactions.FindIndex(pr => pr.Id == reactionId);
+                            //  var newPRs= postReactions.Splice()
+                            postReactions[initalReactionIndex].Reaction.ReactionCount = postReactions[initalReactionIndex].Reaction.ReactionCount + 1;
+                            //anotherPostReaction.Count = (anotherPostReaction.Count + 1);
+                            //newPostReaction.IsNullOrEmpty();
+                            //postReactions.Add(anotherPostReaction);
+                        }
+                    }
+                        reader.Close();
+
+
+                    return postReactions;
+                }
+            }
+        }
 
         public void AddPostReaction(PostReaction postReaction)
         {

--- a/Tabloid/Repositories/PostReactionRepository.cs
+++ b/Tabloid/Repositories/PostReactionRepository.cs
@@ -153,6 +153,8 @@ namespace Tabloid.Repositories
 
                         var reactionId = reader.GetInt32(reader.GetOrdinal("ReactionId"));
                         var anotherPostReaction = postReactions.Find(pr => pr.ReactionId == reactionId);
+                        //var anotherPostReaction = postReactions.FirstOrDefault(pr => pr.ReactionId == reactionId);
+
                         if (anotherPostReaction == null) {
 
                             postReactions.Add(postReaction);

--- a/Tabloid/Repositories/PostReactionRepository.cs
+++ b/Tabloid/Repositories/PostReactionRepository.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Threading.Tasks;
+using Tabloid.Models;
+
+namespace Tabloid.Repositories
+{
+
+    public class PostReactionRepository : BaseRepository, IPostReactionRepository
+
+    {
+        public PostReactionRepository(IConfiguration config) : base(config) { }
+
+
+
+        public List<PostReaction> GetAllReactionsByPostId(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                      SELECT pr.Id, pr.PostId, pr.ReactionId, pr.UserProfileId AS UserProfileIdReactingToPost, 
+                        r.Id, r.Name, r.ImageLocation 
+                        FROM PostReaction pr
+                        JOIN  Reaction r
+                        ON pr.ReactionId = r.Id
+                        WHERE pr.PostId = @id
+                       ";
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    var postReactions = new List<PostReaction>();
+
+                    var reader = cmd.ExecuteReader();
+
+                    while (reader.Read())
+                    {
+                        PostReaction postReaction = new PostReaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            PostId = reader.GetInt32(reader.GetOrdinal("PostId")),
+                            ReactionId = reader.GetInt32(reader.GetOrdinal("ReactionId")),
+                            UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileIdReactingToPost")),
+                            Reaction = new Reaction
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                Name = reader.GetString(reader.GetOrdinal("Name")),
+                                ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation"))
+                            }
+                        };
+
+                        postReactions.Add(postReaction);
+
+                    }
+
+                    reader.Close();
+
+                    return postReactions;
+                }
+            }
+        }
+
+
+        public void AddPostReaction(PostReaction postReaction)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO PostReaction (PostId, ReactionId, UserProfileId)
+                                        OUTPUT INSERTED.ID
+                                        VALUES (@postId, @reactionId, @userProfileId)";
+                    cmd.Parameters.AddWithValue("@postId", postReaction.PostId);
+                    cmd.Parameters.AddWithValue("@reactionId", postReaction.ReactionId);
+                    cmd.Parameters.AddWithValue("@userProfileId", postReaction.UserProfileId);
+
+                    int id = (int)cmd.ExecuteScalar();
+
+                    postReaction.Id = id;
+                }
+            }
+        }
+
+
+    }
+}
+
+

--- a/Tabloid/Repositories/ReactionRepository.cs
+++ b/Tabloid/Repositories/ReactionRepository.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Threading.Tasks;
+using Tabloid.Models;
+
+namespace Tabloid.Repositories
+{
+
+    public class ReactionRepository : BaseRepository, IReactionRepository
+
+    {
+        public ReactionRepository(IConfiguration config) : base(config) { }
+
+        public List<Reaction> GetAllReactions()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                      SELECT r.Id, r.Name, r.ImageLocation
+                        FROM  Reaction r
+                       ";
+
+
+                    var reactions = new List<Reaction>();
+
+                    var reader = cmd.ExecuteReader();
+
+                    while (reader.Read())
+                    {
+                        Reaction reaction = new Reaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation"))
+                        };
+
+                        reactions.Add(reaction);
+
+                    }
+
+                    reader.Close();
+
+                    return reactions;
+                }
+            }
+
+        }
+
+
+
+        public Reaction GetReactionById(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT r.Id, r.Name, r.ImageLocation
+                        FROM  Reaction r
+                       
+                        WHERE r.Id = @id 
+                       ";
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    var reader = cmd.ExecuteReader();
+
+                    if (reader.Read())
+                    {
+                        Reaction reaction = new Reaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation"))
+                        };
+
+                        reader.Close();
+                        return reaction;
+                    }
+                    else
+                    {
+                        reader.Close();
+                        return null;
+                    }
+                }
+            }
+        }
+
+        public void AddReaction(Reaction reaction)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO Reaction (Name, ImageLocation)
+                                        OUTPUT INSERTED.ID
+                                        VALUES (@name, @imageLocation)";
+                    cmd.Parameters.AddWithValue("@name", reaction.Name);
+                    cmd.Parameters.AddWithValue("@imageLocation", reaction.ImageLocation);
+
+                    int id = (int)cmd.ExecuteScalar();
+
+                    reaction.Id = id;
+                }
+            }
+        }
+
+    }
+}
+
+

--- a/Tabloid/Repositories/ReactionRepository.cs
+++ b/Tabloid/Repositories/ReactionRepository.cs
@@ -92,6 +92,7 @@ namespace Tabloid.Repositories
             }
         }
 
+
         public void AddReaction(Reaction reaction)
         {
             using (var conn = Connection)

--- a/Tabloid/Startup.cs
+++ b/Tabloid/Startup.cs
@@ -27,6 +27,10 @@ namespace Tabloid
             services.AddTransient<ITagRepository, TagRepository>();
             services.AddTransient<IPostRepository, PostRepository>();
             services.AddTransient<ICategoryRepository, CategoryRepository>();
+            services.AddTransient<IPostReactionRepository, PostReactionRepository>();
+            services.AddTransient<IReactionRepository, ReactionRepository>();
+
+
 
             var firebaseProjectId = Configuration.GetValue<string>("FirebaseProjectId");
             var googleTokenUrl = $"https://securetoken.google.com/{firebaseProjectId}";

--- a/Tabloid/client/src/App.js
+++ b/Tabloid/client/src/App.js
@@ -4,6 +4,7 @@ import { UserProfileProvider } from "./providers/UserProfileProvider";
 import { TagProvider } from "./providers/TagProvider";
 import { CategoryProvider } from "./providers/CategoryProvider";
 import { PostProvider } from "./providers/PostProvider";
+import { ReactionProvider } from "./providers/ReactionProvider";
 import Header from "./components/Header";
 import ApplicationViews from "./components/ApplicationViews";
 import { CommentProvider } from './providers/CommentProvider';
@@ -20,8 +21,10 @@ function App() {
           <TagProvider>
             <CategoryProvider>
               <CommentProvider>
-                <Header />
-                <ApplicationViews />
+                <ReactionProvider>
+                  <Header />
+                  <ApplicationViews />
+                </ReactionProvider>
               </CommentProvider>
             </CategoryProvider>
           </TagProvider>

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -28,6 +28,7 @@ import UserProfileDetails from "./UserProfiles/UserProfileDetails";
 import UserProfileDeactivation from "./UserProfiles/UserProfileDeactivation";
 import UserProfileReactivation from "./UserProfiles/UserProfileReactivation";
 import UserProfileEdit from "./UserProfiles/UserProfileEdit";
+import ReactionList from "./Reaction/ReactionList";
 export default function ApplicationViews(props) {
   const { isLoggedIn, activeUser, userTypeId } = useContext(UserProfileContext);
   const [refresh, setRefresh] = useState(false);
@@ -116,6 +117,9 @@ export default function ApplicationViews(props) {
         </Route>
         <Route path="/userprofile/edit/:id" exact>
           {isLoggedIn && activeUser.userTypeId === 1 ? <UserProfileEdit /> : <Redirect to="/userprofile" />}
+        </Route>
+        <Route path="/reaction" exact>
+          {isLoggedIn ? <ReactionList /> : <Redirect to="/login" />}
         </Route>
 
       </Switch>

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -13,10 +13,10 @@ import TagList from "./Tag/TagList";
 import TagForm from "./Tag/TagForm";
 import TagEditForm from "./Tag/TagEditForm"
 import TagDelete from "./Tag/TagDelete"
-import CategoryList from "./Category/CategoryList";
-import CategoryAddForm from "./Category/CategoryAddForm";
-import CategoryUpdateForm from "./Category/CategoryUpdateForm";
-import CategoryDelete from "./Category/CategoryDelete";
+import CategoryList from "./category/CategoryList";
+import CategoryAddForm from "./category/CategoryAddForm";
+import CategoryUpdateForm from "./category/CategoryUpdateForm";
+import CategoryDelete from "./category/CategoryDelete";
 import PostList from "./Post/PostList"
 import UserPostList from "./Post/UserPostList"
 import PostDetails from "./Post/PostDetails";

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -13,10 +13,10 @@ import TagList from "./Tag/TagList";
 import TagForm from "./Tag/TagForm";
 import TagEditForm from "./Tag/TagEditForm"
 import TagDelete from "./Tag/TagDelete"
-import CategoryList from "./category/CategoryList";
-import CategoryAddForm from "./category/CategoryAddForm";
-import CategoryUpdateForm from "./category/CategoryUpdateForm";
-import CategoryDelete from "./category/CategoryDelete";
+import CategoryList from "./Category/CategoryList";
+import CategoryAddForm from "./Category/CategoryAddForm";
+import CategoryUpdateForm from "./Category/CategoryUpdateForm";
+import CategoryDelete from "./Category/CategoryDelete";
 import PostList from "./Post/PostList"
 import UserPostList from "./Post/UserPostList"
 import PostDetails from "./Post/PostDetails";

--- a/Tabloid/client/src/components/Post/Post.js
+++ b/Tabloid/client/src/components/Post/Post.js
@@ -25,7 +25,7 @@ const Post = ({ post }) => {
                 <CardBody>
                     <Row>
                         <Col sm="4">
-                            {window.location.href == "http://localhost:3000/post" ?
+                            {window.location.href == "http://localhost:3000/" ?
                                 <NavLink to={`post/details/${post.id}`}><Button to={`/post/details/${post.id}`} >Details</Button></NavLink> : <NavLink to={`details/${post.id}`}><Button to={`details/${post.id}`} >Details</Button></NavLink>}
                         </Col>
                         <Col sm="4">

--- a/Tabloid/client/src/components/Post/Post.js
+++ b/Tabloid/client/src/components/Post/Post.js
@@ -27,8 +27,8 @@ const Post = ({ post }) => {
                 <CardBody>
                     <Row>
                         <Col sm="4">
-                            {window.location.href == "http://localhost:3000/" ?
-                                <NavLink to={`post/details/${post.id}`}><Button to={`/post/details/${post.id}`} >Details</Button></NavLink> : <NavLink to={`details/${post.id}`}><Button to={`details/${post.id}`} >Details</Button></NavLink>}
+                            {window.location.href == "http://localhost:3000/post" ?
+                                <NavLink to={`post/details/${post.id}`}><Button >Details</Button></NavLink> : <NavLink to={`details/${post.id}`}><Button >Details</Button></NavLink>}
                         </Col>
                         <Col sm="4">
                             {window.location.href == "http://localhost:3000/post" ?

--- a/Tabloid/client/src/components/Post/PostDetails.js
+++ b/Tabloid/client/src/components/Post/PostDetails.js
@@ -1,15 +1,16 @@
 import React, { useContext, useEffect, useState } from "react";
 import { PostContext, PostProvider } from "../../providers/PostProvider";
-import { Card, CardImg, CardBody, Row, Button, Col } from "reactstrap";
+import { Card, CardImg, CardBody, Row, Button, Col, CardFooter } from "reactstrap";
 import { useHistory } from "react-router-dom";
 
 import { Link, NavLink, useParams } from "react-router-dom";
 import PostReactionList from "../Reaction/PostReactionList";
 import { ReactionContext } from "../../providers/ReactionProvider";
+import AddPostReactionList from "../Reaction/AddPostReactionList";
 
 const PostDetails = () => {
 
-    const { postReactions, getAllReactionsForPost } = useContext(ReactionContext);
+    const { postReactions, getAllReactionsForPost, allReactionTypes, getAllReactions } = useContext(ReactionContext);
     const { getPost, post } = useContext(PostContext);
     const { id } = useParams();
     const history = useHistory();
@@ -17,6 +18,7 @@ const PostDetails = () => {
     useEffect(() => {
         getPost(id);
         getAllReactionsForPost(id);
+        getAllReactions();
     }, []);
     const calculateReadTime = () => {
         let time = 0;
@@ -72,6 +74,15 @@ const PostDetails = () => {
                         <PostReactionList key={post.id} />)
                         : null}
                 </Row>
+                <CardFooter>
+                    <Row>
+                        {(allReactionTypes.length != 0)
+                            //||  postReactions.map(pr => pr.userId.includes("") 
+                            ? (
+                                <AddPostReactionList key={post.id} />)
+                            : null}
+                    </Row>
+                </CardFooter>
             </Card>
         </>
 

--- a/Tabloid/client/src/components/Post/PostDetails.js
+++ b/Tabloid/client/src/components/Post/PostDetails.js
@@ -4,17 +4,19 @@ import { Card, CardImg, CardBody, Row, Button, Col } from "reactstrap";
 import { useHistory } from "react-router-dom";
 
 import { Link, NavLink, useParams } from "react-router-dom";
+import PostReactionList from "../Reaction/PostReactionList";
+import { ReactionContext } from "../../providers/ReactionProvider";
 
 const PostDetails = () => {
 
-
+    const { postReactions, getAllReactionsForPost } = useContext(ReactionContext);
     const { getPost, post } = useContext(PostContext);
     const { id } = useParams();
     const history = useHistory();
 
     useEffect(() => {
-        debugger
         getPost(id);
+        getAllReactionsForPost(id);
     }, []);
     const calculateReadTime = () => {
         let time = 0;
@@ -64,9 +66,12 @@ const PostDetails = () => {
                 <CardBody>
                     <CardImg className="postDetailImg" top src={post.imageLocation} alt={post.title} />
                     <p>{post.content}</p>
-
-
                 </CardBody>
+                <Row>
+                    {postReactions.length != 0 ? (
+                        <PostReactionList key={post.id} />)
+                        : null}
+                </Row>
             </Card>
         </>
 

--- a/Tabloid/client/src/components/Post/PostDetails.js
+++ b/Tabloid/client/src/components/Post/PostDetails.js
@@ -13,7 +13,7 @@ const PostDetails = () => {
     const history = useHistory();
 
     useEffect(() => {
-
+        debugger
         getPost(id);
     }, []);
     const calculateReadTime = () => {

--- a/Tabloid/client/src/components/Reaction/AddPostReaction.js
+++ b/Tabloid/client/src/components/Reaction/AddPostReaction.js
@@ -1,0 +1,48 @@
+import React, { useContext } from "react";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
+import { Card, Button, Col, Row, CardImg } from "reactstrap";
+import { ReactionContext } from "../../providers/ReactionProvider";
+import { useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
+
+export default function AddPostReaction({ reaction }) {
+    const { activeUser } = useContext(UserProfileContext);
+    const { addPostReaction, getAllReactionsForPost } = useContext(ReactionContext);
+
+    const { id } = useParams();
+    const history = useHistory();
+
+    const handleAddPostReaction = (e) => {
+        debugger
+        e.preventDefault();
+        addPostReaction({
+            postId: parseInt(id),
+            reactionId: reaction.id,
+            userProfileId: activeUser.id
+        })
+            .then(() => getAllReactionsForPost(id))
+            .catch((err) => alert(`An error ocurred: ${err.message}`));
+    };
+    return (
+        <Col>
+
+
+
+            <CardImg type="button" top className="border-button" id={reaction.id} src={reaction.imageLocation} alt={reaction.name} onClick={e => handleAddPostReaction(e)} />
+
+            {/* {activeUser.userTypeId === 1 &&
+                        <>
+                            <Col sm="1">
+                                <Button type="button" id={category.id} href={`/category/edit/${category.id}`}>Edit</Button>
+                            </Col>
+                            <Col sm="1">
+                                <Button type="button" color="danger" id={category.id} href={`/category/delete/${category.id}`}>Delete</Button>
+
+                            </Col>
+                        </>
+                    } */}
+
+
+        </Col >
+    );
+}

--- a/Tabloid/client/src/components/Reaction/AddPostReactionList.js
+++ b/Tabloid/client/src/components/Reaction/AddPostReactionList.js
@@ -1,0 +1,36 @@
+import React, { useContext, useEffect, useState } from "react";
+import { ReactionContext } from "../../providers/ReactionProvider";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
+import Reaction from "./Reaction";
+import { Button, Col, Row, Collapse } from "reactstrap";
+import AddPostReaction from "./AddPostReaction";
+export default function AddPostReactionList() {
+
+    const { allReactionTypes, getAllReactions } = useContext(ReactionContext);
+    const { activeUser } = useContext(UserProfileContext);
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggle = () => setIsOpen(!isOpen);
+
+    useEffect(() => {
+        getAllReactions();
+    }, []);
+
+    return (
+        <Col sm="12" md={{ size: 9, offset: 0 }}>
+
+            {activeUser.userTypeId === 1 &&
+                <>
+                    <Button color="primary" onClick={toggle} style={{ marginBottom: '1rem' }}>Add Reaction</Button>
+                    <Collapse isOpen={isOpen}>
+                        <Row>
+                            {allReactionTypes.map(r =>
+                                <AddPostReaction key={r.id} reaction={r} />
+                            )}
+                        </Row>
+                    </Collapse>
+                </>
+            }
+        </Col>
+    );
+}

--- a/Tabloid/client/src/components/Reaction/PostReaction.js
+++ b/Tabloid/client/src/components/Reaction/PostReaction.js
@@ -4,7 +4,6 @@ import { Card, Button, Col, Row, CardImg } from "reactstrap";
 
 export default function PostReaction({ postReaction }) {
     const { activeUser } = useContext(UserProfileContext);
-    console.log(postReaction, "reaction")
     return (
 
         <>

--- a/Tabloid/client/src/components/Reaction/PostReaction.js
+++ b/Tabloid/client/src/components/Reaction/PostReaction.js
@@ -11,10 +11,10 @@ export default function PostReaction({ postReaction }) {
 
             <Col>
                 <CardImg top src={postReaction.reaction.imageLocation} className="UserProfileAvatar" />
+
+                <span>{postReaction.reaction.reactionCount}</span>
             </ Col>
-            <Col>
-                {/* Add count function  */}
-            </Col>
+
             {/* {activeUser.userTypeId === 1 &&
                         <>
                             <Col sm="1">

--- a/Tabloid/client/src/components/Reaction/PostReaction.js
+++ b/Tabloid/client/src/components/Reaction/PostReaction.js
@@ -2,20 +2,20 @@ import React, { useContext } from "react";
 import { UserProfileContext } from "../../providers/UserProfileProvider";
 import { Card, Button, Col, Row, CardImg } from "reactstrap";
 
-export default function Reaction({ reaction }) {
+export default function PostReaction({ postReaction }) {
     const { activeUser } = useContext(UserProfileContext);
-
+    console.log(postReaction, "reaction")
     return (
-        <Col>
-            <Card body>
-                <Row>
-                    <Col sm="9">
-                        <strong>{reaction.name}</strong>
-                    </Col>
-                    <Col>
-                        <CardImg top className="UserProfileAvatar" src={reaction.imageLocation} alt={reaction.name} />
-                    </ Col>
-                    {/* {activeUser.userTypeId === 1 &&
+
+        <>
+
+            <Col>
+                <CardImg top src={postReaction.reaction.imageLocation} className="UserProfileAvatar" />
+            </ Col>
+            <Col>
+                {/* Add count function  */}
+            </Col>
+            {/* {activeUser.userTypeId === 1 &&
                         <>
                             <Col sm="1">
                                 <Button type="button" id={category.id} href={`/category/edit/${category.id}`}>Edit</Button>
@@ -26,8 +26,7 @@ export default function Reaction({ reaction }) {
                             </Col>
                         </>
                     } */}
-                </Row>
-            </Card >
-        </Col >
+        </>
+
     );
 }

--- a/Tabloid/client/src/components/Reaction/PostReactionList.js
+++ b/Tabloid/client/src/components/Reaction/PostReactionList.js
@@ -22,41 +22,41 @@ export default function PostReactionList() {
         getAllReactionsForPost(id);
     }, []);
 
-    let i = 0;
-    let stateTypesToChange = [];
-    let stateCountsToChange = [...reactionCount]
+    // let i = 0;
+    // let stateTypesToChange = [];
+    // let stateCountsToChange = [...reactionCount]
 
-    const reactionList = () => {
-        postReactions.map(reaction => {
-            debugger
-            console.log(reaction)
-            if (stateTypesToChange.includes(reaction.reactionId)) {
-                //stateCountsToChange[event.target.id] = event.target.value;
-                stateTypesToChange.find((previousReaction) => previousReaction.id == reaction.id)
-                {
+    // const reactionList = () => {
+    //     postReactions.map(reaction => {
+    //         debugger
+    //         console.log(reaction)
+    //         if (stateTypesToChange.includes(reaction.reactionId)) {
+    //             //stateCountsToChange[event.target.id] = event.target.value;
+    //             stateTypesToChange.find((previousReaction) => previousReaction.id == reaction.id)
+    //             {
 
-                }
+    //             }
 
-                //setReactionCount[reaction.reactionId] = { reaction };
-            } else {
-                let singleReaction = { id: reaction.id, postId: reaction.postId, userProfileId: reaction.userProfileId, reactionId: reaction.reactionId, reaction: { id: reaction.reaction.id, name: reaction.reaction.name, imageLocation: reaction.reaction.imageLocation } };
-                debugger
-                stateTypesToChange.push(singleReaction)
-                // stateTypesToChange[i] = { ...stateTypesToChange[i], ...singleReaction }
-                // debugger
-                // i = i + 1;
-                //setReactionTypesInPost({ id: reaction.id, postId: reaction.postId, userProfileId: reaction.userProfileId, reactionId: reaction.reactionId });
+    //             //setReactionCount[reaction.reactionId] = { reaction };
+    //         } else {
+    //             let singleReaction = { id: reaction.id, postId: reaction.postId, userProfileId: reaction.userProfileId, reactionId: reaction.reactionId, reaction: { id: reaction.reaction.id, name: reaction.reaction.name, imageLocation: reaction.reaction.imageLocation } };
+    //             debugger
+    //             stateTypesToChange.push(singleReaction)
+    //             // stateTypesToChange[i] = { ...stateTypesToChange[i], ...singleReaction }
+    //             // debugger
+    //             // i = i + 1;
+    //             //setReactionTypesInPost({ id: reaction.id, postId: reaction.postId, userProfileId: reaction.userProfileId, reactionId: reaction.reactionId });
 
-                console.log("singleReaction", singleReaction)
-                console.log("NewTypesArray", stateTypesToChange)
-            }
-        })
+    //             console.log("singleReaction", singleReaction)
+    //             console.log("NewTypesArray", stateTypesToChange)
+    //         }
+    //     })
 
-    }
+    // }
 
-    useEffect(() => {
-        reactionList()
-    }, [])
+    // useEffect(() => {
+    //     reactionList()
+    // }, [])
 
 
     if (postReactions == "") {
@@ -66,16 +66,16 @@ export default function PostReactionList() {
     }
 
     return (
-        <Col sm="12" md={{ size: 6, offset: 3 }}>
+        <Col >
 
 
-            {/* <Row>
+            <Row>
                 {postReactions.map(pr =>
 
                     <PostReaction key={pr.id} postReaction={pr} />
 
                 )}
-            </Row> */}
+            </Row>
 
         </Col>
     );

--- a/Tabloid/client/src/components/Reaction/PostReactionList.js
+++ b/Tabloid/client/src/components/Reaction/PostReactionList.js
@@ -66,7 +66,7 @@ export default function PostReactionList() {
     }
 
     return (
-        <Col >
+        <Col sm="12" md={{ size: 5, offset: 0 }}>
 
 
             <Row>

--- a/Tabloid/client/src/components/Reaction/PostReactionList.js
+++ b/Tabloid/client/src/components/Reaction/PostReactionList.js
@@ -1,0 +1,82 @@
+import React, { useContext, useEffect, useState } from "react";
+import { ReactionContext } from "../../providers/ReactionProvider";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
+import PostReaction from "./PostReaction";
+import { Button, Col, Row } from "reactstrap";
+import { useParams } from "react-router-dom";
+import PostDetails from "../Post/PostDetails";
+export default function PostReactionList() {
+
+    const [reactionTypesInPost, setReactionTypesInPost] = useState([]);
+    const [reactionCount, setReactionCount] = useState([]);
+    const { postReactions, getAllReactionsForPost } = useContext(ReactionContext);
+    const { activeUser } = useContext(UserProfileContext);
+    const { id } = useParams();
+
+
+
+
+
+
+    useEffect(() => {
+        getAllReactionsForPost(id);
+    }, []);
+
+    let i = 0;
+    let stateTypesToChange = [];
+    let stateCountsToChange = [...reactionCount]
+
+    const reactionList = () => {
+        postReactions.map(reaction => {
+            debugger
+            console.log(reaction)
+            if (stateTypesToChange.includes(reaction.reactionId)) {
+                //stateCountsToChange[event.target.id] = event.target.value;
+                stateTypesToChange.find((previousReaction) => previousReaction.id == reaction.id)
+                {
+
+                }
+
+                //setReactionCount[reaction.reactionId] = { reaction };
+            } else {
+                let singleReaction = { id: reaction.id, postId: reaction.postId, userProfileId: reaction.userProfileId, reactionId: reaction.reactionId, reaction: { id: reaction.reaction.id, name: reaction.reaction.name, imageLocation: reaction.reaction.imageLocation } };
+                debugger
+                stateTypesToChange.push(singleReaction)
+                // stateTypesToChange[i] = { ...stateTypesToChange[i], ...singleReaction }
+                // debugger
+                // i = i + 1;
+                //setReactionTypesInPost({ id: reaction.id, postId: reaction.postId, userProfileId: reaction.userProfileId, reactionId: reaction.reactionId });
+
+                console.log("singleReaction", singleReaction)
+                console.log("NewTypesArray", stateTypesToChange)
+            }
+        })
+
+    }
+
+    useEffect(() => {
+        reactionList()
+    }, [])
+
+
+    if (postReactions == "") {
+        return (
+            null
+        )
+    }
+
+    return (
+        <Col sm="12" md={{ size: 6, offset: 3 }}>
+
+
+            {/* <Row>
+                {postReactions.map(pr =>
+
+                    <PostReaction key={pr.id} postReaction={pr} />
+
+                )}
+            </Row> */}
+
+        </Col>
+    );
+}

--- a/Tabloid/client/src/components/Reaction/Reaction.js
+++ b/Tabloid/client/src/components/Reaction/Reaction.js
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { UserProfileContext } from "../../providers/UserProfileProvider";
-import { Card, Button, Col, Row } from "reactstrap";
+import { Card, Button, Col, Row, CardImg } from "reactstrap";
 
 export default function Category({ reaction }) {
     const { activeUser } = useContext(UserProfileContext);

--- a/Tabloid/client/src/components/Reaction/Reaction.js
+++ b/Tabloid/client/src/components/Reaction/Reaction.js
@@ -1,0 +1,33 @@
+import React, { useContext } from "react";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
+import { Card, Button, Col, Row } from "reactstrap";
+
+export default function Category({ reaction }) {
+    const { activeUser } = useContext(UserProfileContext);
+
+    return (
+        <Col>
+            <Card body>
+                <Row>
+                    <Col sm="9">
+                        <strong>{reaction.name}</strong>
+                    </Col>
+                    <Col>
+                        <CardImg top className="UserProfileAvatar" src={reaction.imageLocation} alt={reaction.name} />
+                    </ Col>
+                    {/* {activeUser.userTypeId === 1 &&
+                        <>
+                            <Col sm="1">
+                                <Button type="button" id={category.id} href={`/category/edit/${category.id}`}>Edit</Button>
+                            </Col>
+                            <Col sm="1">
+                                <Button type="button" color="danger" id={category.id} href={`/category/delete/${category.id}`}>Delete</Button>
+
+                            </Col>
+                        </>
+                    } */}
+                </Row>
+            </Card >
+        </Col >
+    );
+}

--- a/Tabloid/client/src/components/Reaction/ReactionList.js
+++ b/Tabloid/client/src/components/Reaction/ReactionList.js
@@ -3,8 +3,9 @@ import { ReactionContext } from "../../providers/ReactionProvider";
 import { UserProfileContext } from "../../providers/UserProfileProvider";
 import Reaction from "./Reaction";
 import { Button, Col, Row } from "reactstrap";
-export default function CategoryList() {
-    const { getAllReactions, allReactionTypes } = useContext(ReactionContext);
+export default function ReactionList() {
+
+    const { allReactionTypes, getAllReactions } = useContext(ReactionContext);
     const { activeUser } = useContext(UserProfileContext);
 
 
@@ -16,7 +17,7 @@ export default function CategoryList() {
         <Col sm="12" md={{ size: 6, offset: 3 }}>
             {activeUser.userTypeId === 1 &&
                 <Row className="justify-content-center">
-                    <Button type="button" href={`/reaction/add`}>Add Category</Button>
+                    <Button type="button" href={`/reaction/add`}>Add Reaction</Button>
                 </Row>
             }
             <section>

--- a/Tabloid/client/src/components/Reaction/ReactionList.js
+++ b/Tabloid/client/src/components/Reaction/ReactionList.js
@@ -1,0 +1,29 @@
+import React, { useContext, useEffect } from "react";
+import { ReactionContext } from "../../providers/ReactionProvider";
+import { UserProfileContext } from "../../providers/UserProfileProvider";
+import Reaction from "./Reaction";
+import { Button, Col, Row } from "reactstrap";
+export default function CategoryList() {
+    const { getAllReactions, allReactionTypes } = useContext(ReactionContext);
+    const { activeUser } = useContext(UserProfileContext);
+
+
+    useEffect(() => {
+        getAllReactions();
+    }, []);
+
+    return (
+        <Col sm="12" md={{ size: 6, offset: 3 }}>
+            {activeUser.userTypeId === 1 &&
+                <Row className="justify-content-center">
+                    <Button type="button" href={`/reaction/add`}>Add Category</Button>
+                </Row>
+            }
+            <section>
+                {allReactionTypes.map(r =>
+                    <Reaction key={r.id} reaction={r} />
+                )}
+            </section>
+        </Col>
+    );
+}

--- a/Tabloid/client/src/index.css
+++ b/Tabloid/client/src/index.css
@@ -24,3 +24,11 @@ p {
 .postDetailImg {
   max-width: 125em;
 }
+
+.border-button {
+  outline: solid 5px #FC5185;
+  transition: outline 0.6s linear;
+  margin: 0.5em; /* Increased margin since the outline expands outside the element */
+}
+
+.border-button:hover { outline-width: 10px; }

--- a/Tabloid/client/src/providers/PostProvider.js
+++ b/Tabloid/client/src/providers/PostProvider.js
@@ -21,7 +21,6 @@ export function PostProvider(props) {
     };
 
     const addPost = (post) => {
-        debugger
         getToken().then((token) => fetch("/api/post", {
             method: "POST",
             headers: {
@@ -47,6 +46,7 @@ export function PostProvider(props) {
             .then(setPosts);
     };
     const getPost = (id) => {
+        debugger
         getToken().then((token) => fetch(`/api/post/${id}`, {
             method: "GET",
             headers: {

--- a/Tabloid/client/src/providers/PostProvider.js
+++ b/Tabloid/client/src/providers/PostProvider.js
@@ -46,7 +46,6 @@ export function PostProvider(props) {
             .then(setPosts);
     };
     const getPost = (id) => {
-        debugger
         getToken().then((token) => fetch(`/api/post/${id}`, {
             method: "GET",
             headers: {

--- a/Tabloid/client/src/providers/ReactionProvider.js
+++ b/Tabloid/client/src/providers/ReactionProvider.js
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import * as firebase from "firebase/app";
 
-export const CommentContext = React.createContext();
+export const ReactionContext = React.createContext();
 
-export const CommentProvider = (props) => {
+export const ReactionProvider = (props) => {
 
     //All Reaction Types
     const [allReactionTypes, setAllReactionTypes] = useState([]);
@@ -71,8 +71,8 @@ export const CommentProvider = (props) => {
 
     return (
 
-        <CommentContext.Provider value={{ getAllReactions, getAllReactionsForPost, addReaction, addPostReaction, allReactionTypes, postReactions }}>
+        <ReactiionContext.Provider value={{ getAllReactions, getAllReactionsForPost, addReaction, addPostReaction, allReactionTypes, postReactions }}>
             {props.children}
-        </CommentContext.Provider>
+        </ReactiionContext.Provider>
     );
 }

--- a/Tabloid/client/src/providers/ReactionProvider.js
+++ b/Tabloid/client/src/providers/ReactionProvider.js
@@ -71,8 +71,8 @@ export const ReactionProvider = (props) => {
 
     return (
 
-        <ReactiionContext.Provider value={{ getAllReactions, getAllReactionsForPost, addReaction, addPostReaction, allReactionTypes, postReactions }}>
+        <ReactionContext.Provider value={{ getAllReactions, getAllReactionsForPost, addReaction, addPostReaction, allReactionTypes, postReactions }}>
             {props.children}
-        </ReactiionContext.Provider>
+        </ReactionContext.Provider>
     );
 }

--- a/Tabloid/client/src/providers/ReactionProvider.js
+++ b/Tabloid/client/src/providers/ReactionProvider.js
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import * as firebase from "firebase/app";
+
+export const CommentContext = React.createContext();
+
+export const CommentProvider = (props) => {
+
+    //All Reaction Types
+    const [allReactionTypes, setAllReactionTypes] = useState([]);
+
+    //Single Reaction Type... needed?
+    //const [reaction, setReaction] = useState({});
+
+    //All Reactions on a post
+    const [postReactions, setpostReactions] = useState([]);
+
+    //Single Reaction on a post.. needed?
+    //const [postReaction, setPostReaction] = useState({});
+
+    const getToken = () => firebase.auth().currentUser.getIdToken();
+
+    const getAllReactions = () => {
+        return getToken().then((token) => {
+            fetch("/api/reaction", {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${token}`
+                }
+            }).then(resp => resp.json()).then(setAllReactionTypes);
+        })
+    };
+
+    const getAllReactionsForPost = (postId) => {
+        return getToken().then((token) => {
+            fetch(`/api/reaction/GetAllReactionsByPost/${postId}`, {
+                method: "GET",
+                headers: {
+                    Authorization: `Bearer ${token}`
+                }
+            }).then(resp => resp.json()).then(setpostReactions);
+        })
+    };
+
+    const addReaction = (newReaction) => {
+        return getToken().then((token) => {
+            fetch("/api/reaction", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`
+                },
+                body: JSON.stringify(newReaction)
+            })
+        })
+    };
+
+    const addPostReaction = (newPostReaction) => {
+        return getToken().then((token) => {
+            fetch("/api/reaction/PostReaction", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${token}`
+                },
+                body: JSON.stringify(newPostReaction)
+            })
+        })
+    };
+
+
+
+    return (
+
+        <CommentContext.Provider value={{ getAllReactions, getAllReactionsForPost, addReaction, addPostReaction, allReactionTypes, postReactions }}>
+            {props.children}
+        </CommentContext.Provider>
+    );
+}

--- a/Tabloid/client/src/providers/ReactionProvider.js
+++ b/Tabloid/client/src/providers/ReactionProvider.js
@@ -32,7 +32,7 @@ export const ReactionProvider = (props) => {
 
     const getAllReactionsForPost = (postId) => {
         return getToken().then((token) => {
-            fetch(`/api/reaction/GetAllReactionsByPost/${postId}`, {
+            fetch(`/api/reaction/GetAllReactionsCountedByPost/${postId}`, {
                 method: "GET",
                 headers: {
                     Authorization: `Bearer ${token}`


### PR DESCRIPTION
# Description
Completed Add Post Reaction and view post reactions on Post Details 
 
Fixes #35  #36

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

Load Tabloid from remote repository
Run ReactionSeed.sql file in SQL folder

Npm start/launch Tabloid
Login 

Post Reaction - View existing reactions
goto route: "/post/details/1"
Previously added reaction images will be visible at the bottom of the post
- a count of each time a reaction type has been selected by users for that post is given on the right of the image
 
Post Reaction Add & Post Reaction List
Click on any "Post" from navbar
Click on any post "Details” button
View post details and click on "Add Reaction" Button on bottom of post
Once a reaction is chosen the "Add Reaction" options should disappear and your reaction should be added to reactions on the post.
- if your reaction was already on the post, you will see the reaction number change.
- if your reaction type is new to the post, you will see the reaction image added with a reaction number of "1"

- reactions can not be removed
- only 1 reaction from a user can be added per post

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
